### PR TITLE
Use env to find out a proper path for python3

### DIFF
--- a/rev-proxy-grapher.py
+++ b/rev-proxy-grapher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -tt
+#!/usr/bin/env python3 -tt
 # -*- coding: utf-8 -*-
 #
 from __future__ import (absolute_import,


### PR DESCRIPTION
Hi @mricon !

It's better to use `/usr/bin/env` than static path for python3.
In my case on OS X using virtualenv originally script didn't work for me.

```bash
evilroot@Karols-MacBook-Pro:~/repos/rev-proxy-grapher (*)
> ./rev-proxy-grapher.py --topology examples/topology.yaml                                                                                                                                                          
zsh: ./rev-proxy-grapher.py: bad interpreter: /usr/bin/python3: no such file or directory
```

after change everything works as it should - also it's more sexy... 🤣 