### PR TITLE
Remove -tt from pyton3 shebang

### DIFF
--- a/rev-proxy-grapher.py
+++ b/rev-proxy-grapher.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3 -tt
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 from __future__ import (absolute_import,


### PR DESCRIPTION
Python3 does not have a `-tt` command option, however it will silently discard the option. Currently the following error occurs on Debian unstable and the latest Fedora when I try to run rvg.py:

    /usr/bin/env: ‘python3 -tt’: No such file or directory

Removing the `-tt` lets the script run without errors